### PR TITLE
Fixing unformatted help and admin pages & Removing reference to Council at Statistics page & Fixing login email links

### DIFF
--- a/templates/email/fmsj/login.html
+++ b/templates/email/fmsj/login.html
@@ -1,6 +1,15 @@
 [%
+SET url = c.uri_for_action('auth/token', token);
+SET language = url.match('^https?://lt\.manrupi') ? 'lt' 
+         : url.match('^https?://en\.manrupi') ? 'en' 
+         : 'lt-en';
 
-email_summary = "Spustelėkite toliau pateiktą nuorodą, kad patvirtintumėte savo el. pašto adresą ir prisijunkite prie " _ site_name _ " / Click the link below to confirm your email address and log into " _ site_name;
+SET lt_text = "Spustelėkite toliau pateiktą nuorodą, kad patvirtintumėte savo el. pašto adresą ir prisijunkite prie " _ site_name;
+SET en_text = "Click the link below to confirm your email address and log into " _ site_name;
+
+email_summary = language == 'lt' ? lt_text
+                : language == 'en' ? en_text
+                : lt_text _ " / " _ en_text;
 email_columns = 1;
 
 PROCESS '_email_settings.html';
@@ -10,10 +19,11 @@ INCLUDE '_email_top.html';
 %]
 
 <th style="[% td_style %][% only_column_style %]">
+[% IF language.match('lt') %]
   <h1 style="[% h1_style %]">Dėkojame, kad naudojatės [% site_name %]</h1>
   <p style="[% p_style %]">Spustelėkite toliau esančią nuorodą, kad patvirtintumėte savo el. pašto adresą ir prisijunkite prie [% site_name %].</p>
   <p style="margin: 20px auto; text-align: center">
-    <a style="[% button_style %]" href="[% c.uri_for_action( 'auth/token', token ) | replace('https://', 'https://lt.') | replace('http://', 'http://lt.') %]">Taip, tai mano adresas</a>
+    <a style="[% button_style %]" href="[% url | replace('https://man', 'https://lt.man') | replace('http://man', 'http://lt.man') %]">Taip, tai mano adresas</a>
   </p>
   <p style="[% p_style %]">
     [% IF c.get_param('r').match('waste') %]
@@ -22,11 +32,15 @@ INCLUDE '_email_top.html';
     Kai tai padarysite, galėsite peržiūrėti ir tvarkyti visas ataskaitas ir atnaujinimus, kuriuos atlikote [% site_name %] meniu „Jūsų paskyra“.
     [% END %]
   </p>
+[% END %]
+[% IF language.match('lt-en') %]
   <h2 style="[% h2_style %]; text-align:center; padding-top: 2em;">*** English ***</h2>
+[% END %]
+[% IF language.match('en') %]
   <h1 style="[% h1_style %]">Thanks for using [% site_name %]</h1>
   <p style="[% p_style %]">Please click on the link below to confirm your email address and log into [% site_name %].</p>
   <p style="margin: 20px auto; text-align: center">
-    <a style="[% button_style %]" href="[% c.uri_for_action( 'auth/token', token ) %]">Yes, this is my address</a>
+    <a style="[% button_style %]" href="[% url | replace('https://man', 'https://en.man') | replace('http://man', 'http://en.man') %]">Yes, this is my address</a>
   </p>
   <p style="[% p_style %]">
     [% IF c.get_param('r').match('waste') %]
@@ -36,6 +50,7 @@ INCLUDE '_email_top.html';
     updates you&rsquo;ve made from the &ldquo;Your account&rdquo; menu on [% site_name %].
     [% END %]
   </p>
+[% END %]
 </th>
 
 [% INCLUDE '_email_bottom.html' %]

--- a/templates/email/fmsj/login.txt
+++ b/templates/email/fmsj/login.txt
@@ -1,8 +1,23 @@
-Subject: [% site_name %] paskyros informacija / Your [% site_name %] account details
+[%
+SET url = c.uri_for_action('auth/token', token);
+SET language = url.match('^https?://lt\.manrupi') ? 'lt' 
+         : url.match('^https?://en\.manrupi') ? 'en' 
+         : 'lt-en';
 
+SET lt_text = [% site_name %] _ " paskyros informacija";
+SET en_text = "Your " _ [% site_name %] _ " account details";
+
+SET email_subject = language == 'lt' ? lt_text
+                : language == 'en' ? en_text
+                : lt_text _ " / " _ en_text;
+%]
+
+Subject: [% email_subject %]
+
+[% IF language.match('lt') %]
 Spustelėkite toliau esančią nuorodą, kad patvirtintumėte savo el. pašto adresą.
 
-[% c.uri_for_action( 'auth/token', token ) | replace('https://', 'https://lt.') | replace('http://', 'http://lt.') %]
+[% url | replace('https://man', 'https://lt.man') | replace('http://man', 'http://lt.man') %]
 
 [% IF c.get_param('r').match('waste') %]
 Kai tai padarysite, galėsite peržiūrėti arba keisti savo atliekų prenumeratą ir surinkimą.
@@ -14,13 +29,16 @@ Viso gero,
 [% site_name %] komanda
 
 Šis el. laiškas buvo išsiųstas automatiškai iš automatinės el. pašto paskyros, todėl į jį neatsakykite.
-
+[% END %]
+[% IF language.match('lt-en') %]
 
 *** ENGLISH ***
 
+[% END %]
+[% IF language.match('en') %]
 Please click on the link below to confirm your email address.
 
-[% c.uri_for_action( 'auth/token', token ) %]
+[% url | replace('https://man', 'https://en.man') | replace('http://man', 'http://en.man') %]
 
 [% IF c.get_param('r').match('waste') %]
 Once you've done this, you'll be able to view or amend your waste subscriptions and collections.
@@ -33,3 +51,4 @@ updates you've made on [% site_name %].
 
 This email was sent automatically, from an unmonitored email account - so
 please do not reply to it.
+[% END %]

--- a/templates/web/fmsj/about/cookies.html
+++ b/templates/web/fmsj/about/cookies.html
@@ -55,4 +55,4 @@ cookie, 30 minutes</p>
 <h2>4. More information on Cookies</h2>
 <p>More information about cookies can be found on this link: <a href="www.allaboutcookies.org" target="_blank">www.allaboutcookies.org</a></p>
 
-[% INCLUDE 'footer.html' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsj/about/faq-en-gb.html
+++ b/templates/web/fmsj/about/faq-en-gb.html
@@ -105,4 +105,4 @@ Email: <a href='mailto:jon.switters@lisboncouncil.net' target='_blank' class='ur
 <p>Email: <a href='mailto:administracija@jonava.lt'>administracija@jonava.lt</a></p>
 
 
-[% INCLUDE 'footer.html' pagefooter = 'yes' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsj/about/faq-lt.html
+++ b/templates/web/fmsj/about/faq-lt.html
@@ -131,4 +131,4 @@ href="https://www.mysociety.org/helpus/">Get Involved page</a>.</dd>
 
 </dl>
 
-[% INCLUDE 'footer.html' pagefooter = 'yes' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsj/about/privacy.html
+++ b/templates/web/fmsj/about/privacy.html
@@ -107,4 +107,4 @@ Email: <a href='mailto:jon.switters@lisboncouncil.net' target='_blank' class='ur
 <p>&nbsp;</p>
 
 
-[% INCLUDE 'footer.html' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsj/about/tos.html
+++ b/templates/web/fmsj/about/tos.html
@@ -27,4 +27,4 @@
 
 
 
-[% INCLUDE 'footer.html' pagefooter = 'yes' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsj/admin/header.html
+++ b/templates/web/fmsj/admin/header.html
@@ -1,0 +1,22 @@
+[%
+    SET admin = 1;
+    SET bodyclass = bodyclass.defined && bodyclass != '' ? bodyclass : 'twothirdswidthpage'
+    INCLUDE 'header.html' bodyclass=bodyclass _ ' admin';
+%]
+
+[%    
+    IF !bodyclass.match('mappage')
+        INCLUDE 'admin/_navigation.html';
+    END;
+%]
+
+<style type="text/css">
+dt { clear: left; float: left; font-weight: bold; }
+dd { margin-left: 8em !important; }
+.adminhidden { color: #666666; }
+.error { color: red; }
+select { width: auto; max-width: 100%; }
+.sm { font-size: smaller; }
+</style>
+
+[% IF !bodyclass.match('mappage') %]<h1>[% title %]</h1>[% END %]

--- a/templates/web/fmsj/admin/header.html
+++ b/templates/web/fmsj/admin/header.html
@@ -4,11 +4,9 @@
     INCLUDE 'header.html' bodyclass=bodyclass _ ' admin';
 %]
 
-[%    
-    IF !bodyclass.match('mappage')
-        INCLUDE 'admin/_navigation.html';
-    END;
-%]
+[% IF !bodyclass.match('mappage') %]
+[%   INCLUDE 'admin/_navigation.html' %]
+[% END %]
 
 <style type="text/css">
 dt { clear: left; float: left; font-weight: bold; }

--- a/templates/web/fmsj/contact/index.html
+++ b/templates/web/fmsj/contact/index.html
@@ -25,4 +25,4 @@
 
 [% TRY %][% INCLUDE 'contact/address.html' %][% CATCH file %][% END %]
 
-[% INCLUDE 'footer.html' pagefooter = 'yes' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsj/contact/index.html
+++ b/templates/web/fmsj/contact/index.html
@@ -1,0 +1,28 @@
+[% extra_js = [
+    version('/js/contact.js')
+] -%]
+[% INCLUDE 'header.html',
+    title = loc('Contact Us')
+    robots = 'noindex,nofollow'
+    bodyclass = 'twothirdswidthpage'
+%]
+
+[% INCLUDE 'about/_sidebar.html' %]
+
+<h1>[% loc('Contact the team') %]</h1>
+
+[% INCLUDE 'contact/form.html' %]
+
+[% TRY %]
+    [% INCLUDE 'contact/_footer.html' %]
+[% CATCH file %]
+    <h4>[% loc("Don't like forms?") %]</h4>
+
+    <p>
+    [% tprintf( loc("You can contact technical support on <a href='mailto:%s'>%s</a>"), contact_email, contact_email) %]
+    </p>
+[% END %]
+
+[% TRY %][% INCLUDE 'contact/address.html' %][% CATCH file %][% END %]
+
+[% INCLUDE 'footer.html' pagefooter = 'yes' %]

--- a/templates/web/fmsj/footer_help.html
+++ b/templates/web/fmsj/footer_help.html
@@ -1,0 +1,16 @@
+[% RETURN IF ajax_loading ~%]
+                </div><!-- .content role=main -->
+                    [% IF pagefooter %]
+                    <footer role="contentinfo">
+                        [% INCLUDE 'front/footer-marketing.html' %]
+                    </footer>
+                    [% END %]
+
+            </div><!-- .container -->
+        </div><!-- .table-cell -->
+    </div> <!-- .wrapper -->
+
+    [% INCLUDE 'common_footer_tags.html' %]
+
+</body>
+</html>

--- a/templates/web/fmsj/reports/index.html
+++ b/templates/web/fmsj/reports/index.html
@@ -1,0 +1,79 @@
+[% USE Number.Format -%]
+[% extra_js = [
+    version('/vendor/chart.min.js'),
+    version('/vendor/accessible-autocomplete.min.js'),
+    version('/js/dashboard.js')
+] -%]
+[%
+    problems_reported = problems_reported_by_period.last | format_number;
+    problems_fixed = problems_fixed_by_period.last | format_number;
+    last_seven_reported = last_seven_days.problems_total | format_number;
+    last_seven_updated = last_seven_days.updated_total | format_number;
+    last_seven_fixed = last_seven_days.fixed_total | format_number;
+    other_categories_formatted = other_categories | format_number;
+-%]
+[% INCLUDE 'header.html', title = loc('Dashboard'), bodyclass = 'dashboard' %]
+
+<div class="dashboard-header">
+    <h1>[% loc('Dashboard') %]
+    [% IF body %] – [% body.name %] [% END %]
+    </h1>
+</div>
+
+<div class="dashboard-row">
+    <div class="dashboard-item dashboard-item--12">
+        <h2>[% loc('All time') %]</h2>
+        <div class="labelled-line-chart">
+            <canvas id="chart-all-reports" width="600" height="250"
+                data-labels="[[% FOR period IN problem_periods %]&quot;[% period %]&quot;[% IF NOT loop.last %],[% END %][% END %]]"
+                data-values-reports="[[% problems_reported_by_period.join(',') %]]"
+                data-values-fixed="[[% problems_fixed_by_period.join(',') %]]"
+                ></canvas>
+            <span class="label" data-datasetindex="0"><strong style="color: #D97B0C">[% tprintf(nget("%s problem reported", "%s problems reported", problems_reported_by_period.last), decode(problems_reported) _ '</strong>') %]</span>
+            <span class="label" data-datasetindex="1"><strong style="color: #56A54A">[% tprintf(nget("%s problem marked as fixed", "%s problems marked as fixed", problems_fixed_by_period.last), decode(problems_fixed) _ '</strong>') %]</span>
+        </div>
+    </div>
+</div>
+
+<div class="dashboard-row">
+    <div class="dashboard-item dashboard-item--6">
+        <h2 class="dashboard-subheading">[% loc('Last 7 days') %]</h2>
+        <div class="dashboard-sparklines">
+            <div>
+                <div class="labelled-sparkline">
+                    <canvas width="200" height="50" data-color="#D97B0C" data-values="[% last_seven_days.problems.join(' ') %]"></canvas>
+                    <span class="label" data-datasetindex="0"><strong style="color: #D97B0C;">[% tprintf(nget("%s problem reported", "%s problems reported", last_seven_days.problems_total), decode(last_seven_reported) _ '</strong>') %]</span>
+                </div>
+            </div>
+            <div>
+                <div class="labelled-sparkline">
+                    <canvas width="200" height="50" data-color="#269AE9" data-values="[% last_seven_days.updated.join(' ') %]"></canvas>
+                    <span class="label" data-datasetindex="0"><strong style="color: #269AE9;">[% tprintf(nget("%s update on problems", "%s updates on problems", last_seven_days.updated_total), decode(last_seven_updated) _ '</strong>') %]</span>
+                </div>
+            </div>
+            <div>
+                <div class="labelled-sparkline">
+                    <canvas width="200" height="50" data-color="#56A54A" data-values="[% last_seven_days.fixed.join(' ') %]"></canvas>
+                    <span class="label" data-datasetindex="0"><strong style="color: #56A54A;">[% tprintf(nget("%s problem marked as fixed", "%s problems marked as fixed", last_seven_days.fixed_total), decode(last_seven_fixed) _ '</strong>') %]</span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="dashboard-item dashboard-item--6">
+        <h2 class="dashboard-subheading">[% loc('Top 5 most used categories') %]</h2>
+        <p>[% loc('Number of problems reported in each category, in the last 7 days.') %]</p>
+        <table class="dashboard-ranking-table">
+            <tbody>
+              [% FOR line IN top_five_categories %]
+                [% line_count = line.count | format_number ~%]
+                <tr><td>[% line.category %]</td><td>[% tprintf(nget("%s report", "%s reports", line.count), decode(line_count)) %]</td></tr>
+              [% END %]
+            </tbody>
+            <tfoot>
+                <tr><td>[% loc('Other categories') %]</td><td>[% tprintf(nget("%s report", "%s reports", other_categories), decode(other_categories_formatted)) %]</td></tr>
+            </tfoot>
+        </table>
+    </div>
+</div>
+
+[% INCLUDE 'footer.html' pagefooter = 'yes' %]


### PR DESCRIPTION
Fixing issues:

- [x] [Hide "Show reports in your area" box from "All reports" as it is just one area](https://lisboncouncil.atlassian.net/browse/FIX-57?atlOrigin=eyJpIjoiYmQxODQzYWE3NjUwNGI2MjlmYzkzY2U3YWRiMmZiMzgiLCJwIjoiaiJ9)
- [x] [HIde / remove "Top 5 responsive councils" from "All reports" as it is just one council/body](https://lisboncouncil.atlassian.net/browse/FIX-58?atlOrigin=eyJpIjoiN2YwMTQyNWYwYjgwNDg4ZDhhZjU0MjI4MmRmZTE4OWEiLCJwIjoiaiJ9)
- [x] [Contact form unformatted](https://lisboncouncil.atlassian.net/browse/FIX-59?atlOrigin=eyJpIjoiMDhmYjEwMTg0NmE4NDFmZjkxNjAyYWE4M2E4MjRjODgiLCJwIjoiaiJ9)
- [x] Footer displayed properly at Help pages
- [x] Admin site unformatted
- [x] Fixing email links and language for login email