### PR TITLE
Add dynamic OpenStreetMap to fmsj homepage

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Root.pm
+++ b/perllib/FixMyStreet/App/Controller/Root.pm
@@ -82,6 +82,9 @@ sub index : Path : Args(0) {
         $c->detach;
     }
 
+    # Aggiungi dati mappa per home page (se il cobrand lo supporta)
+    $c->cobrand->call_hook('front_page_data', $c);
+
     $c->forward('/auth/get_csrf_token');
 }
 

--- a/perllib/FixMyStreet/Cobrand/fmsj.pm
+++ b/perllib/FixMyStreet/Cobrand/fmsj.pm
@@ -4,8 +4,66 @@ use parent 'FixMyStreet::Cobrand::Default';
 use strict;
 use warnings;
 
+use FixMyStreet::Map;
+
 sub country {
     return 'LT';
+}
+
+sub front_page_data {
+    my ($self, $c) = @_;
+
+    # Coordinate di Jonava
+    my $lat = 55.06818;
+    my $lon = 24.27485;
+    my $zoom = 14;
+
+    # Log per debug
+    $c->log->info("front_page_data called for fmsj cobrand");
+
+    # Recupera problemi recenti per i pins
+    my @problems = eval {
+        $c->model('DB::Problem')->search(
+            { state => { -in => ['confirmed', 'fixed', 'fixed - council', 'fixed - user'] } },
+            { order_by => { -desc => 'confirmed' }, rows => 50 }
+        )->all;
+    };
+    if ($@) {
+        $c->log->error("Error fetching problems: $@");
+        @problems = ();
+    }
+
+    $c->log->info("Found " . scalar(@problems) . " problems for pins");
+
+    my @pins = map {
+        {
+            latitude => $_->latitude,
+            longitude => $_->longitude,
+            colour => $_->is_fixed ? 'green' : 'yellow',
+            id => $_->id,
+            title => $_->title,
+        }
+    } @problems;
+
+    # Genera dati mappa
+    eval {
+        FixMyStreet::Map::display_map($c,
+            latitude => $lat,
+            longitude => $lon,
+            pins => \@pins,
+            any_zoom => 1,
+        );
+    };
+    if ($@) {
+        $c->log->error("Error generating map: $@");
+        return;
+    }
+
+    $c->log->info("Map generated, stash map type: " . ($c->stash->{map}{type} || 'undefined'));
+
+    # Override zoom per avere zoom fisso a 14
+    my $zoom_offset = $c->stash->{map}{zoomOffset} || 0;
+    $c->stash->{map}{zoom} = $zoom - $zoom_offset;
 }
 
 sub _fallback_body_sender {

--- a/templates/web/base/common_scripts.html
+++ b/templates/web/base/common_scripts.html
@@ -17,6 +17,22 @@ IF bodyclass.match('frontpage');
         version('/js/geolocation.js'),
         version('/js/loading-attribute-polyfill.js'),
     );
+    # Carica script mappa se presente nella home page
+    IF map;
+        scripts.push(
+            version('/vendor/jquery-3.6.0.min.js'),
+        );
+        FOR script IN map_js.merge(c.cobrand.call_hook('map_js_extra'));
+            IF script.match('^/');
+                scripts.push(version(script));
+            ELSE;
+                scripts.push(script);
+            END;
+        END;
+        scripts.push(
+            version('/cobrands/fixmystreet/map.js'),
+        );
+    END;
 ELSIF bodyclass.match('alertpage');
     scripts.push(
         version('/js/geolocation.js'),

--- a/templates/web/fmsj/front/recent.html
+++ b/templates/web/fmsj/front/recent.html
@@ -12,11 +12,17 @@
         [% END -%]
     </h2>
 
-    <div class="map-fake">
-        <a href="/reports/Jonava+District+Municipality+Administration?zoom=14&lat=55.06818&lon=24.27485">
-            <img src="/cobrands/fmsj/images/jonava-fake-map.jpeg" alt="Jonava Map" />
-        </a>
-    </div>
+    [% IF map %]
+        [% PROCESS "maps/${map.type}.html" %]
+        [% map_html | safe %]
+        </div><!-- closes #map_box from map_html -->
+    [% ELSE %]
+        <div class="map-fake">
+            <a href="/reports/Jonava+District+Municipality+Administration?zoom=14&lat=55.06818&lon=24.27485">
+                <img src="/cobrands/fmsj/images/jonava-fake-map.jpeg" alt="Jonava Map" />
+            </a>
+        </div>
+    [% END %]
 
     [% TRY %][% INCLUDE "front/pre-recent.html" %][% CATCH file %][% END %]
 

--- a/web/cobrands/fmsj/_frontpage-map.scss
+++ b/web/cobrands/fmsj/_frontpage-map.scss
@@ -1,0 +1,40 @@
+// Front page dynamic map styles
+
+// Prevent mappage #map_box absolute positioning on frontpage
+body.frontpage #map_box {
+    position: relative !important;
+    height: 400px !important;
+    width: 100% !important;
+    top: auto !important;
+    bottom: auto !important;
+    left: auto !important;
+    right: auto !important;
+    margin: 0 0 1em 0 !important;
+    z-index: 1 !important;
+}
+
+body.frontpage #map {
+    position: relative !important;
+    height: 100% !important;
+    width: 100% !important;
+}
+
+body.frontpage #map_sidebar,
+body.frontpage .shadow-wrap:not(.static) {
+    display: none !important;
+}
+
+// Hide extra controls on frontpage map
+body.frontpage .map-links,
+body.frontpage .sub-map-links,
+body.frontpage .map-instructions {
+    display: none !important;
+}
+
+body.frontpage #map_box .olControlAttribution {
+    position: absolute !important;
+    bottom: 5px !important;
+    right: 5px !important;
+    left: auto !important;
+    z-index: 5 !important;
+}

--- a/web/cobrands/fmsj/layout.scss
+++ b/web/cobrands/fmsj/layout.scss
@@ -1,2 +1,3 @@
 @import "_colours";
 @import "../sass/layout";
+@import "_frontpage-map";


### PR DESCRIPTION
Replace the static map image on the fmsj cobrand homepage with an interactive OpenStreetMap that displays recent problem pins. The map is centered on Jonava (55.06818, 24.27485) at zoom level 14.

Changes:
- Add front_page_data hook to fmsj.pm cobrand to generate map data
- Call front_page_data hook from Root.pm controller
- Update recent.html template to render dynamic map with fallback
- Add map script loading for frontpage in common_scripts.html
- Add SCSS styles to properly position map on frontpage

